### PR TITLE
feat: 詳細画面を表示できるようにする

### DIFF
--- a/lib/application/usecases/sign_in_use_case.dart
+++ b/lib/application/usecases/sign_in_use_case.dart
@@ -22,7 +22,7 @@ class SignInUseCase {
         password: password,
       ))
           .user;
-      context.go(RoutePaths.routeList);
+      context.go(RoutePaths.route + RoutePaths.list);
     } on FirebaseAuthException catch (error) {
       var message = FirebaseAuthExt.fromCode(error.code).message;
       FirebaseAuthErrorHandler.handleFirebaseAuthError(

--- a/lib/application/usecases/sign_up_use_case.dart
+++ b/lib/application/usecases/sign_up_use_case.dart
@@ -22,7 +22,7 @@ class SignUpUseCase {
         password: password,
       ))
           .user;
-      context.go(RoutePaths.routeMyPage);
+      context.go(RoutePaths.route + RoutePaths.myPage);
       await FirebaseFirestore.instance.collection('users').doc(user!.uid).set({
         'username': 'ゲスト',
         'email': email,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,10 +49,10 @@ class HomePage extends ConsumerWidget {
     return authStateAsync.when(
       data: (user) {
         if (user != null) {
-          context.go(RoutePaths.routeList);
+          context.go(RoutePaths.route + RoutePaths.list);
           return const ListPage();
         } else {
-          context.go(RoutePaths.routeAuth);
+          context.go(RoutePaths.route + RoutePaths.auth);
           return const AuthPage();
         }
       },

--- a/lib/presentation/pages/list_item_page.dart
+++ b/lib/presentation/pages/list_item_page.dart
@@ -1,0 +1,23 @@
+import 'package:bucket_list_app/presentation/theme/app_strings.dart';
+import 'package:bucket_list_app/presentation/theme/app_text_styles.dart';
+import 'package:bucket_list_app/presentation/widgets/list_item_card_new.dart';
+import 'package:flutter/material.dart';
+
+class ListItemPage extends StatelessWidget {
+  const ListItemPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          AppStrings.appBarTitleListItem,
+          style: AppTextStyles.appBarTextStyle,
+        ),
+      ),
+      body: const Center(
+        child: ListItemCardNew(),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/list_page.dart
+++ b/lib/presentation/pages/list_page.dart
@@ -1,8 +1,10 @@
+import 'package:bucket_list_app/presentation/router/router.dart';
 import 'package:bucket_list_app/presentation/theme/app_strings.dart';
 import 'package:bucket_list_app/presentation/theme/app_text_styles.dart';
 import 'package:bucket_list_app/presentation/theme/theme.dart';
 import 'package:bucket_list_app/presentation/widgets/tab_bar_items.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ListPage extends StatelessWidget {
   const ListPage({super.key});
@@ -29,6 +31,21 @@ class ListPage extends StatelessWidget {
           bottom: TabBarItems(
             tabItems: tabItems,
           ),
+          actions: [
+            IconButton(
+              onPressed: () {
+                context.push(
+                  RoutePaths.route +
+                      RoutePaths.list +
+                      RoutePaths.route +
+                      RoutePaths.listItem,
+                );
+              },
+              icon: const Icon(
+                Icons.add_circle_outline,
+              ),
+            ),
+          ],
         ),
         body: TabBarView(
           children: [

--- a/lib/presentation/pages/my_page.dart
+++ b/lib/presentation/pages/my_page.dart
@@ -33,7 +33,7 @@ class MyPage extends StatelessWidget {
             OutlinedButton(
               onPressed: () async {
                 await FirebaseAuth.instance.signOut();
-                context.go(RoutePaths.routeAuth);
+                context.go(RoutePaths.route + RoutePaths.auth);
               },
               child: const Text(
                 'ログアウト',

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -1,6 +1,7 @@
 import 'package:bucket_list_app/main.dart';
 import 'package:bucket_list_app/presentation/pages/achieved_list_page.dart';
 import 'package:bucket_list_app/presentation/pages/auth_page.dart';
+import 'package:bucket_list_app/presentation/pages/list_item_page.dart';
 import 'package:bucket_list_app/presentation/pages/list_page.dart';
 import 'package:bucket_list_app/presentation/pages/my_page.dart';
 import 'package:bucket_list_app/presentation/widgets/app_bottom_nav.dart';
@@ -9,14 +10,14 @@ import 'package:go_router/go_router.dart';
 
 final rootNavigatorKey = GlobalKey<NavigatorState>();
 final listNavigatorKey =
-    GlobalKey<NavigatorState>(debugLabel: RoutePaths.routeList);
-final achievedNavigatorKey =
-    GlobalKey<NavigatorState>(debugLabel: RoutePaths.routeAchieved);
+    GlobalKey<NavigatorState>(debugLabel: RoutePaths.route + RoutePaths.list);
+final achievedNavigatorKey = GlobalKey<NavigatorState>(
+    debugLabel: RoutePaths.route + RoutePaths.achieved);
 final myPageNavigatorKey =
-    GlobalKey<NavigatorState>(debugLabel: RoutePaths.routeMyPage);
+    GlobalKey<NavigatorState>(debugLabel: RoutePaths.route + RoutePaths.myPage);
 
 final goRouter = GoRouter(
-  initialLocation: RoutePaths.routeList,
+  initialLocation: RoutePaths.route + RoutePaths.list,
   navigatorKey: rootNavigatorKey,
   routes: [
     StatefulShellRoute.indexedStack(
@@ -29,8 +30,14 @@ final goRouter = GoRouter(
           navigatorKey: listNavigatorKey,
           routes: [
             GoRoute(
-              path: RoutePaths.routeList,
+              path: RoutePaths.route + RoutePaths.list,
               builder: (context, state) => const ListPage(),
+              routes: [
+                GoRoute(
+                  path: RoutePaths.listItem,
+                  builder: (context, state) => const ListItemPage(),
+                ),
+              ],
             ),
           ],
         ),
@@ -39,7 +46,7 @@ final goRouter = GoRouter(
           navigatorKey: achievedNavigatorKey,
           routes: [
             GoRoute(
-              path: RoutePaths.routeAchieved,
+              path: RoutePaths.route + RoutePaths.achieved,
               builder: (context, state) => const AchievedListPage(),
             ),
           ],
@@ -49,7 +56,7 @@ final goRouter = GoRouter(
           navigatorKey: myPageNavigatorKey,
           routes: [
             GoRoute(
-              path: RoutePaths.routeMyPage,
+              path: RoutePaths.route + RoutePaths.myPage,
               builder: (context, state) => const MyPage(),
             ),
           ],
@@ -73,8 +80,7 @@ class RoutePaths {
   static const route = '/';
   static const auth = 'auth';
   static const list = 'list';
-  static const routeAuth = '/auth';
-  static const routeList = '/list';
-  static const routeAchieved = '/achieved';
-  static const routeMyPage = '/mypage';
+  static const listItem = 'listItem';
+  static const achieved = 'achieved';
+  static const myPage = 'myPage';
 }

--- a/lib/presentation/theme/app_strings.dart
+++ b/lib/presentation/theme/app_strings.dart
@@ -42,6 +42,7 @@ class AppStrings {
   static const appBarTitleList = 'やってみたいことリスト';
   static const appBarTitleAchieved = '達成済みリスト';
   static const appBarTitleMyPage = 'マイページ';
+  static const appBarTitleListItem = '詳細';
 
   static const bottomNavListLabel = 'リスト';
   static const bottomNavAchievedLabel = '達成済み';

--- a/lib/presentation/theme/sizes.dart
+++ b/lib/presentation/theme/sizes.dart
@@ -5,6 +5,7 @@ class Sizes {
   static const p14 = 14.0;
   static const p20 = 20.0;
   static const p28 = 28.0;
+  static const p32 = 32.0;
   static const p40 = 40.0;
   static const p44 = 44.0;
   static const p48 = 48.0;

--- a/lib/presentation/widgets/list_item_card_edit.dart
+++ b/lib/presentation/widgets/list_item_card_edit.dart
@@ -1,0 +1,117 @@
+import 'package:bucket_list_app/presentation/theme/app_strings.dart';
+import 'package:bucket_list_app/presentation/theme/sizes.dart';
+import 'package:bucket_list_app/presentation/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ListItemCardEdit extends StatelessWidget {
+  const ListItemCardEdit({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 480,
+      child: Card(
+        margin: const EdgeInsets.all(Sizes.p20),
+        color: MaterialTheme.lightScheme().surfaceContainer,
+        // Set the shape of the card using a rounded rectangle border with a 8 pixel radius
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        clipBehavior: Clip.antiAliasWithSaveLayer,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            ListTile(
+              trailing: PopupMenuButton(
+                icon: const Icon(Icons.more_vert),
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: '編集',
+                    child: ListTile(
+                      leading: const Icon(Icons.edit),
+                      title: const Text('編集'),
+                      onTap: () {},
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: '削除',
+                    child: ListTile(
+                      leading: const Icon(Icons.delete),
+                      title: const Text('削除'),
+                      onTap: () {},
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Image.network(
+              'https://static-00.iconduck.com/assets.00/flutter-icon-1651x2048-ojswpayr.png',
+              height: 200,
+              width: double.infinity,
+              fit: BoxFit.fitHeight,
+            ),
+            Container(
+              padding: const EdgeInsets.fromLTRB(15, 15, 15, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Cards Title 2',
+                    style: TextStyle(
+                      fontSize: 24,
+                      color: Colors.grey[800],
+                    ),
+                  ),
+                  Container(height: 10),
+                  Text(
+                    AppStrings.appBarTitleListItem,
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: Colors.grey[700],
+                    ),
+                  ),
+                  const SizedBox(
+                    height: Sizes.p32,
+                  ),
+                  Row(
+                    children: <Widget>[
+                      const Spacer(),
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.transparent,
+                        ),
+                        child: Text(
+                          '閉じる',
+                          style: TextStyle(
+                            color: MaterialTheme.lightScheme().primary,
+                          ),
+                        ),
+                        onPressed: () {
+                          context.pop();
+                        },
+                      ),
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.transparent,
+                        ),
+                        child: Text(
+                          '達成！',
+                          style: TextStyle(
+                            color: MaterialTheme.lightScheme().primary,
+                          ),
+                        ),
+                        onPressed: () {},
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Container(height: 5),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/list_item_card_new.dart
+++ b/lib/presentation/widgets/list_item_card_new.dart
@@ -1,0 +1,93 @@
+import 'package:bucket_list_app/presentation/theme/sizes.dart';
+import 'package:bucket_list_app/presentation/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ListItemCardNew extends StatelessWidget {
+  const ListItemCardNew({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 480,
+      child: Card(
+        margin: const EdgeInsets.all(Sizes.p20),
+        color: MaterialTheme.lightScheme().surfaceContainer,
+        // Set the shape of the card using a rounded rectangle border with a 8 pixel radius
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        clipBehavior: Clip.antiAliasWithSaveLayer,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Image.network(
+              'https://static-00.iconduck.com/assets.00/flutter-icon-1651x2048-ojswpayr.png',
+              height: 200,
+              width: double.infinity,
+              fit: BoxFit.fitHeight,
+            ),
+            Container(
+              padding: const EdgeInsets.fromLTRB(15, 15, 15, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Form(
+                    child: TextFormField(
+                      decoration: const InputDecoration(
+                        hintText: 'やりたいこと',
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Form(
+                    child: TextFormField(
+                      decoration: const InputDecoration(
+                        hintText: 'カテゴリ',
+                      ),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: Sizes.p32,
+                  ),
+                  Row(
+                    children: <Widget>[
+                      const Spacer(),
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.transparent,
+                        ),
+                        child: Text(
+                          '閉じる',
+                          style: TextStyle(
+                            color: MaterialTheme.lightScheme().primary,
+                          ),
+                        ),
+                        onPressed: () {
+                          context.pop();
+                        },
+                      ),
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.transparent,
+                        ),
+                        child: Text(
+                          '完了',
+                          style: TextStyle(
+                            color: MaterialTheme.lightScheme().primary,
+                          ),
+                        ),
+                        onPressed: () {},
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Container(height: 5),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 対応内容
<!-- 対応背景、妥協点を記述する -->
<!-- 対応したissueのURLを添付する -->
<!-- issue分割した場合は新たに作成したissueのURLを添付する -->
- 一覧画面から詳細画面へ遷移できるようにする
- #29 

## やったこと
<!-- このPR内でやったこと -->
- 一覧画面に「+」ボタンの追加
- 「+」ボタンタップで詳細画面へ遷移
- 詳細画面でアイテム追加時のカードを表示

## やっていないこと
<!-- このPRでやっていないこと -->
<!-- 別途対応する場合は対応予定のissueのURL -->
- カード内の詳細なデザイン
- 詳細画面での入力時、ボタンタップ時の処理
- 上記は #30 で対応予定

## ScreenShots
<!-- Before / After が分かるものを添付する -->
<img width="50%" src="https://github.com/shmzzzz/bucket_list_app/assets/85086833/eaa5c0bd-c342-429d-b762-a6c9ee2d34ca">

